### PR TITLE
Java version 11+ supported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,27 @@
 			<artifactId>jaxb-api</artifactId> <version>2.1</version>
 			</dependency>
 		-->
+
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.1</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.3.0.1</version>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!--
 			for unzipping-->
 		<!--

--- a/pom.xml
+++ b/pom.xml
@@ -45,27 +45,6 @@
 			<artifactId>jaxb-api</artifactId> <version>2.1</version>
 			</dependency>
 		-->
-
-		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>2.3.3</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.1</version>
-			<scope>runtime</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0.1</version>
-			<scope>runtime</scope>
-		</dependency>
-
 		<!--
 			for unzipping-->
 		<!--
@@ -126,6 +105,36 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>Java-11+</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>jakarta.xml.bind</groupId>
+					<artifactId>jakarta.xml.bind-api</artifactId>
+					<version>2.3.3</version>
+				</dependency>
+
+				<dependency>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+					<version>2.3.1</version>
+					<scope>runtime</scope>
+				</dependency>
+
+				<dependency>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-core</artifactId>
+					<version>2.3.0.1</version>
+					<scope>runtime</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	
 	<description>Tool for generating html pages for your family tree created in Ancestry (http://ancestry.nethar.com) application. It can be used as standalone application or as a plugin of Ancestry. Application is absolutely free.</description>
 	<url>http://sirsi.wz.cz/Ancestry2html.php</url>

--- a/pom.xml
+++ b/pom.xml
@@ -184,8 +184,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The JAXB API has been completely removed from Java since Java 11.

I have added the necessary dependencies so that the program can be compiled and run correctly in Java version 11 and higher.